### PR TITLE
Support manual beacon implementation

### DIFF
--- a/newrelic/NewRelicPlugin.php
+++ b/newrelic/NewRelicPlugin.php
@@ -41,4 +41,10 @@ class NewRelicPlugin extends BasePlugin
 		}
 	}
 
+	public function addTwigExtension()
+	{
+		Craft::import('plugins.newrelic.twigextensions.NewRelicTwigExtension');
+		return new NewRelicTwigExtension();
+	}
+
 }

--- a/newrelic/twigextensions/NewRelicTwigExtension.php
+++ b/newrelic/twigextensions/NewRelicTwigExtension.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Craft;
+
+use Twig_Extension;
+
+class NewRelicTwigExtension extends \Twig_Extension
+{
+
+    /**
+     * Returns the name of the extension.
+     *
+     * @return string The extension name
+     */
+    public function getName()
+    {
+        return 'newrelic';
+    }
+
+    /**
+     * Returns a list of functions to add to the existing list.
+     *
+     * @return array An array of functions
+     */
+    public function getFunctions()
+    {
+        return array(
+            new \Twig_SimpleFunction(
+                'newrelic_get_browser_timing_header',
+                array($this, 'newrelic_get_browser_timing_header'),
+                array('is_safe' => array('html'))
+            ),
+            new \Twig_SimpleFunction(
+                'newrelic_get_browser_timing_footer',
+                array($this, 'newrelic_get_browser_timing_footer'),
+                array('is_safe' => array('html'))
+            ),
+        );
+    }
+
+    /**
+     * Get New Relic timing header
+     *
+     * @return string
+     */
+    public function newrelic_get_browser_timing_header() {
+        if (extension_loaded('newrelic')) {
+            return newrelic_get_browser_timing_header();
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Get New Relic timing footer
+     *
+     * @return string
+     */
+    public function newrelic_get_browser_timing_footer() {
+        if (extension_loaded('newrelic')) {
+            return newrelic_get_browser_timing_footer();
+        } else {
+            return null;
+        }
+    }
+
+}


### PR DESCRIPTION
Adds {{ newrelic_get_browser_timing_header() }} and {{ newrelic_get_browser_timing_footer() }} Twig functions for [New Relic page load timing](https://docs.newrelic.com/docs/agents/php-agent/features/page-load-timing-php). This allows setting php_flag[newrelic.browser_monitoring.auto_instrument] = false.
